### PR TITLE
Added blur event to select-field

### DIFF
--- a/e2e/select-field.e2e-spec.ts
+++ b/e2e/select-field.e2e-spec.ts
@@ -24,6 +24,7 @@ describe('Select field', () => {
   it('should match previous single mode screenshot with validation', (done) => {
     element(by.css('#screenshot-select-field-single-mode .sky-input-group.sky-btn')).click();
     element(by.css('.sky-modal-btn-close')).click();
+    element(by.css('body')).click();
     SkyHostBrowser.moveCursorOffScreen();
     expect('#screenshot-select-field-single-mode-wrapper').toMatchBaselineScreenshot(done, {
       screenshotName: 'select-field-single-mode-validation'

--- a/src/app/public/modules/select-field/fixtures/select-field.component.fixture.html
+++ b/src/app/public/modules/select-field/fixtures/select-field.component.fixture.html
@@ -12,7 +12,7 @@
     [singleSelectPlaceholderText]="singleSelectPlaceholderText"
     [pickerHeading]="pickerHeading"
     [ngModel]="formData.modelValue"
-    (touched)="onTouch()"
+    (blur)="onTouch()"
     (ngModelChange)="onModelChange($event)"
   >
   </sky-select-field>

--- a/src/app/public/modules/select-field/fixtures/select-field.component.fixture.html
+++ b/src/app/public/modules/select-field/fixtures/select-field.component.fixture.html
@@ -12,7 +12,7 @@
     [singleSelectPlaceholderText]="singleSelectPlaceholderText"
     [pickerHeading]="pickerHeading"
     [ngModel]="formData.modelValue"
-    (blur)="onTouch()"
+    (blur)="onBlur()"
     (ngModelChange)="onModelChange($event)"
   >
   </sky-select-field>

--- a/src/app/public/modules/select-field/fixtures/select-field.component.fixture.html
+++ b/src/app/public/modules/select-field/fixtures/select-field.component.fixture.html
@@ -12,7 +12,7 @@
     [singleSelectPlaceholderText]="singleSelectPlaceholderText"
     [pickerHeading]="pickerHeading"
     [ngModel]="formData.modelValue"
-    (blur)="onTouch()"
+    (touched)="onTouch()"
     (ngModelChange)="onModelChange($event)"
   >
   </sky-select-field>

--- a/src/app/public/modules/select-field/fixtures/select-field.component.fixture.html
+++ b/src/app/public/modules/select-field/fixtures/select-field.component.fixture.html
@@ -12,5 +12,7 @@
     [singleSelectPlaceholderText]="singleSelectPlaceholderText"
     [pickerHeading]="pickerHeading"
     [ngModel]="formData.modelValue"
-    (ngModelChange)="onModelChange($event)">
+    (blur)="onTouch()"
+    (ngModelChange)="onModelChange($event)"
+  >
   </sky-select-field>

--- a/src/app/public/modules/select-field/fixtures/select-field.component.fixture.ts
+++ b/src/app/public/modules/select-field/fixtures/select-field.component.fixture.ts
@@ -25,7 +25,7 @@ export class SkySelectFieldTestComponent implements OnInit, OnDestroy {
   public singleSelectOpenButtonTitle: string;
   public singleSelectPlaceholderText: string;
   public pickerHeading: string;
-  public touched = false;
+  public touched = 0;
 
   public data = new BehaviorSubject<any[]>([]);
 
@@ -61,6 +61,6 @@ export class SkySelectFieldTestComponent implements OnInit, OnDestroy {
   }
 
   public onTouch() {
-    this.touched = true;
+    this.touched += 1;
   }
 }

--- a/src/app/public/modules/select-field/fixtures/select-field.component.fixture.ts
+++ b/src/app/public/modules/select-field/fixtures/select-field.component.fixture.ts
@@ -25,6 +25,7 @@ export class SkySelectFieldTestComponent implements OnInit, OnDestroy {
   public singleSelectOpenButtonTitle: string;
   public singleSelectPlaceholderText: string;
   public pickerHeading: string;
+  public touched = false;
 
   public data = new BehaviorSubject<any[]>([]);
 
@@ -57,5 +58,9 @@ export class SkySelectFieldTestComponent implements OnInit, OnDestroy {
 
   public setValue(value: any) {
     this.formData.modelValue = value;
+  }
+
+  public onTouch() {
+    this.touched = true;
   }
 }

--- a/src/app/public/modules/select-field/fixtures/select-field.component.fixture.ts
+++ b/src/app/public/modules/select-field/fixtures/select-field.component.fixture.ts
@@ -60,7 +60,7 @@ export class SkySelectFieldTestComponent implements OnInit, OnDestroy {
     this.formData.modelValue = value;
   }
 
-  public onTouch() {
+  public onBlur() {
     this.touched += 1;
   }
 }

--- a/src/app/public/modules/select-field/select-field.component.html
+++ b/src/app/public/modules/select-field/select-field.component.html
@@ -1,4 +1,7 @@
-<div class="sky-select-field">
+<div
+  class="sky-select-field"
+  (focusout)="onTouched()"
+>
   <ng-container
     *ngTemplateOutlet="(selectMode === 'multiple') ? multipleSelectMode : singleSelectMode ">
   </ng-container>

--- a/src/app/public/modules/select-field/select-field.component.html
+++ b/src/app/public/modules/select-field/select-field.component.html
@@ -1,6 +1,6 @@
 <div
   class="sky-select-field"
-  (focusout)="onTouched()"
+  (focusout)="onHostFocusOut()"
 >
   <ng-container
     *ngTemplateOutlet="(selectMode === 'multiple') ? multipleSelectMode : singleSelectMode ">

--- a/src/app/public/modules/select-field/select-field.component.spec.ts
+++ b/src/app/public/modules/select-field/select-field.component.spec.ts
@@ -147,7 +147,7 @@ describe('Select field component', () => {
       expect(selectField.pickerHeading).toEqual('heading');
     });
 
-    it('should trigger blur event on touch', fakeAsync(() => {
+    it('should trigger blur event when focus is lost', fakeAsync(() => {
       fixture.detectChanges();
 
       setValue(undefined);

--- a/src/app/public/modules/select-field/select-field.component.spec.ts
+++ b/src/app/public/modules/select-field/select-field.component.spec.ts
@@ -136,6 +136,16 @@ describe('Select field component', () => {
       expect(selectField.singleSelectPlaceholderText).toEqual('placeholder');
       expect(selectField.pickerHeading).toEqual('heading');
     });
+
+    it('should trigger blur event onTouch', fakeAsync(() => {
+      fixture.detectChanges();
+      setValue(undefined);
+      openPicker();
+      fixture.detectChanges();
+      closePicker();
+      fixture.detectChanges();
+      expect(component.touched).toBeTruthy();
+    }));
   });
 
   describe('multiple select', () => {

--- a/src/app/public/modules/select-field/select-field.component.spec.ts
+++ b/src/app/public/modules/select-field/select-field.component.spec.ts
@@ -11,11 +11,21 @@ import {
   SkyAppTestUtility
 } from '@blackbaud/skyux-builder/runtime/testing/browser';
 
-import { SkyModalService } from '@skyux/modals';
+import {
+  SkyModalService
+} from '@skyux/modals';
 
-import { SkySelectFieldComponent } from './select-field.component';
-import { SkySelectFieldFixturesModule } from './fixtures/select-field-fixtures.module';
-import { SkySelectFieldTestComponent } from './fixtures/select-field.component.fixture';
+import {
+  SkySelectFieldComponent
+} from './select-field.component';
+
+import {
+  SkySelectFieldFixturesModule
+} from './fixtures/select-field-fixtures.module';
+
+import {
+  SkySelectFieldTestComponent
+} from './fixtures/select-field.component.fixture';
 
 describe('Select field component', () => {
   let fixture: ComponentFixture<SkySelectFieldTestComponent>;
@@ -137,14 +147,27 @@ describe('Select field component', () => {
       expect(selectField.pickerHeading).toEqual('heading');
     });
 
-    it('should trigger touched event onTouch', fakeAsync(() => {
+    it('should trigger blur event on touch', fakeAsync(() => {
       fixture.detectChanges();
+
       setValue(undefined);
       openPicker();
       fixture.detectChanges();
+
+      const selectFieldContainer: HTMLElement = fixture.nativeElement.querySelector('.sky-select-field');
+      SkyAppTestUtility.fireDomEvent(selectFieldContainer, 'focusout');
+      fixture.detectChanges();
+
       closePicker();
       fixture.detectChanges();
-      expect(component.touched).toBeTruthy();
+
+      SkyAppTestUtility.fireDomEvent(selectFieldContainer, 'focusout');
+      fixture.detectChanges();
+
+      expect(component.touched).toBe(1);
+
+      SkyAppTestUtility.fireDomEvent(selectFieldContainer, 'focusout');
+      expect(component.touched).toBe(2);
     }));
   });
 

--- a/src/app/public/modules/select-field/select-field.component.spec.ts
+++ b/src/app/public/modules/select-field/select-field.component.spec.ts
@@ -178,6 +178,18 @@ describe('Select field component', () => {
       expect(selectField.value[0].id).toEqual(component.staticData[0].id);
     }));
 
+    it('should ignore redundant value updates from ngModel', fakeAsync(() => {
+      fixture.detectChanges();
+
+      setValue([component.staticData[0]]);
+      fixture.detectChanges();
+      expect(component.touched).toBe(1);
+
+      setValue([component.staticData[0]]);
+      fixture.detectChanges();
+      expect(component.touched).toBe(1);
+    }));
+
     it('should collapse all tokens into one if many options are chosen', fakeAsync(() => {
       fixture.detectChanges();
       setValue([]);
@@ -212,6 +224,19 @@ describe('Select field component', () => {
       fixture.detectChanges();
       setValue(component.staticData[0]);
       expect(selectField.value.id).toEqual(component.staticData[0].id);
+    }));
+
+    it('should ignore redundant value updates from ngModel', fakeAsync(() => {
+      component.selectMode = 'single';
+      fixture.detectChanges();
+
+      setValue(component.staticData[0]);
+      fixture.detectChanges();
+      expect(component.touched).toBe(1);
+
+      setValue(component.staticData[0]);
+      fixture.detectChanges();
+      expect(component.touched).toBe(1);
     }));
 
     it('should select a value from the picker', fakeAsync(() => {

--- a/src/app/public/modules/select-field/select-field.component.spec.ts
+++ b/src/app/public/modules/select-field/select-field.component.spec.ts
@@ -137,7 +137,7 @@ describe('Select field component', () => {
       expect(selectField.pickerHeading).toEqual('heading');
     });
 
-    it('should trigger blur event onTouch', fakeAsync(() => {
+    it('should trigger touched event onTouch', fakeAsync(() => {
       fixture.detectChanges();
       setValue(undefined);
       openPicker();

--- a/src/app/public/modules/select-field/select-field.component.ts
+++ b/src/app/public/modules/select-field/select-field.component.ts
@@ -103,7 +103,7 @@ export class SkySelectFieldComponent implements ControlValueAccessor {
   public pickerHeading: string;
 
   @Output()
-  public blur = new EventEmitter();
+  public touched = new EventEmitter();
 
   public get value(): any {
     return this._value;
@@ -203,7 +203,7 @@ export class SkySelectFieldComponent implements ControlValueAccessor {
 
   public onTouched(): void {
     this._onTouched();
-    this.blur.emit();
+    this.touched.emit();
   }
 
   // Angular automatically constructs these methods.

--- a/src/app/public/modules/select-field/select-field.component.ts
+++ b/src/app/public/modules/select-field/select-field.component.ts
@@ -3,7 +3,9 @@ import {
   ChangeDetectorRef,
   Component,
   forwardRef,
-  Input
+  Input,
+  EventEmitter,
+  Output
 } from '@angular/core';
 
 import {
@@ -99,6 +101,9 @@ export class SkySelectFieldComponent implements ControlValueAccessor {
 
   @Input()
   public pickerHeading: string;
+
+  @Output()
+  public blur = new EventEmitter();
 
   public get value(): any {
     return this._value;
@@ -196,18 +201,21 @@ export class SkySelectFieldComponent implements ControlValueAccessor {
     }
   }
 
+  public onTouched(): void {
+    this._onTouched();
+    this.blur.emit();
+  }
+
   // Angular automatically constructs these methods.
   /* istanbul ignore next */
   public onChange = (value: any) => { };
-  /* istanbul ignore next */
-  public onTouched = () => { };
 
   public registerOnChange(fn: (value: any) => void) {
     this.onChange = fn;
   }
 
   public registerOnTouched(fn: () => void) {
-    this.onTouched = fn;
+    this._onTouched = fn;
   }
 
   public setDisabledState(disabled: boolean) {
@@ -218,6 +226,9 @@ export class SkySelectFieldComponent implements ControlValueAccessor {
   public clearSelection() {
     this.value = undefined;
   }
+
+  /* istanbul ignore next */
+  private _onTouched = () => { };
 
   private setTokensFromValue() {
     // Tokens only appear for multiple select mode.

--- a/src/app/public/modules/select-field/select-field.component.ts
+++ b/src/app/public/modules/select-field/select-field.component.ts
@@ -120,8 +120,7 @@ export class SkySelectFieldComponent implements ControlValueAccessor {
     if (JSON.stringify(this._value) !== JSON.stringify(value)) {
       this._value = value;
       this.onChange(this.value);
-      this._onTouched();
-      this.blur.emit();
+      this.touch();
     }
   }
 
@@ -216,8 +215,7 @@ export class SkySelectFieldComponent implements ControlValueAccessor {
 
   public onTouched(): void {
     if (!this.isModalOpen) {
-      this._onTouched();
-      this.blur.emit();
+      this.touch();
     }
   }
 
@@ -244,6 +242,11 @@ export class SkySelectFieldComponent implements ControlValueAccessor {
 
   /* istanbul ignore next */
   private _onTouched = () => { };
+
+  private touch() {
+    this._onTouched();
+    this.blur.emit();
+  }
 
   private setTokensFromValue() {
     // Tokens only appear for multiple select mode.

--- a/src/app/public/modules/select-field/select-field.component.ts
+++ b/src/app/public/modules/select-field/select-field.component.ts
@@ -13,7 +13,9 @@ import {
   NG_VALUE_ACCESSOR
 } from '@angular/forms';
 
-import { Observable } from 'rxjs/Observable';
+import {
+  Observable
+} from 'rxjs/Observable';
 
 import {
   SkyModalService,
@@ -33,8 +35,13 @@ import {
   SkySelectFieldSelectMode
 } from './types';
 
-import { SkySelectFieldPickerContext } from './select-field-picker-context';
-import { SkySelectFieldPickerComponent } from './select-field-picker.component';
+import {
+  SkySelectFieldPickerContext
+} from './select-field-picker-context';
+
+import {
+  SkySelectFieldPickerComponent
+} from './select-field-picker.component';
 
 @Component({
   selector: 'sky-select-field',
@@ -103,17 +110,18 @@ export class SkySelectFieldComponent implements ControlValueAccessor {
   public pickerHeading: string;
 
   @Output()
-  public touched = new EventEmitter();
+  public blur = new EventEmitter();
 
   public get value(): any {
     return this._value;
   }
 
   public set value(value: any) {
-    if (value !== this._value) {
+    if (JSON.stringify(this._value) !== JSON.stringify(value)) {
       this._value = value;
       this.onChange(this.value);
-      this.onTouched();
+      this._onTouched();
+      this.blur.emit();
     }
   }
 
@@ -133,6 +141,7 @@ export class SkySelectFieldComponent implements ControlValueAccessor {
   private _disabled: boolean;
   private _selectMode: SkySelectFieldSelectMode;
   private _value: any;
+  private isModalOpen = false;
 
   constructor(
     private changeDetector: ChangeDetectorRef,
@@ -156,6 +165,8 @@ export class SkySelectFieldComponent implements ControlValueAccessor {
   }
 
   public openPicker() {
+    this.isModalOpen = true;
+
     (
       this.pickerHeading ?
         Observable.of(this.pickerHeading) :
@@ -186,7 +197,7 @@ export class SkySelectFieldComponent implements ControlValueAccessor {
               this.writeValue(result.data);
             }
           }
-          this.onTouched();
+          this.isModalOpen = false;
         });
       });
   }
@@ -204,8 +215,10 @@ export class SkySelectFieldComponent implements ControlValueAccessor {
   }
 
   public onTouched(): void {
-    this._onTouched();
-    this.touched.emit();
+    if (!this.isModalOpen) {
+      this._onTouched();
+      this.blur.emit();
+    }
   }
 
   // Angular automatically constructs these methods.

--- a/src/app/public/modules/select-field/select-field.component.ts
+++ b/src/app/public/modules/select-field/select-field.component.ts
@@ -110,9 +110,11 @@ export class SkySelectFieldComponent implements ControlValueAccessor {
   }
 
   public set value(value: any) {
-    this._value = value;
-    this.onChange(this.value);
-    this.onTouched();
+    if (value !== this._value) {
+      this._value = value;
+      this.onChange(this.value);
+      this.onTouched();
+    }
   }
 
   public get singleSelectModeValue(): string {

--- a/src/app/visual/select-field/select-field-visual.component.html
+++ b/src/app/visual/select-field/select-field-visual.component.html
@@ -6,7 +6,8 @@
       name="single"
       [ngModel]="model.single"
       [data]="data"
-      required>
+      required
+    >
     </sky-select-field>
   </div>
 </div>
@@ -16,7 +17,8 @@
     selectMode="multiple"
     name="multiple"
     [ngModel]="model.multiple"
-    [data]="data">
+    [data]="data"
+  >
   </sky-select-field>
 </div>
 


### PR DESCRIPTION
Issue: #10 
Docs: https://github.com/blackbaud/skyux2-docs/pull/228

I expect there may be some concerns about the name `blur` and I can change it. I felt that it is what that event means and this component doesn't have it, so it seemed right. But I also realize that we may just want to completely avoid "reserved" event names.