### PR TITLE
changed css to target both single and multi on invalid input

### DIFF
--- a/src/app/public/modules/select-field/select-field.component.scss
+++ b/src/app/public/modules/select-field/select-field.component.scss
@@ -41,6 +41,6 @@
   }
 }
 
-:host(.ng-invalid.ng-touched) .sky-input-group {
+:host(.ng-invalid.ng-touched) .sky-select-field-btn {
   @include sky-field-status(invalid);
 }


### PR DESCRIPTION
Css for invalid state was only targeting the single sky select.  By changing to .sky-select-field-btn, it will target both a single sky select and multi sky select.

This should solve Issue https://github.com/blackbaud/skyux-select-field/issues/19